### PR TITLE
fix: support humantime_serde in flush-period field

### DIFF
--- a/crates/fluvio-connector-package/src/config/mod.rs
+++ b/crates/fluvio-connector-package/src/config/mod.rs
@@ -500,7 +500,7 @@ pub struct ConsumerOffsetConfig {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub start: Option<OffsetConfig>,
     pub strategy: OffsetStrategyConfig,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(with = "humantime_serde", skip_serializing_if = "Option::is_none", default)]
     pub flush_period: Option<Duration>,
 }
 
@@ -1424,7 +1424,7 @@ mod tests {
         //then
         assert_eq!(
             config_ser,
-            "start:\n  absolute: 10\nstrategy: manual\nflush-period:\n  secs: 60\n  nanos: 0\n"
+            "start:\n  absolute: 10\nstrategy: manual\nflush-period: 1m\n"
         );
     }
 
@@ -1437,9 +1437,7 @@ mod tests {
             start:
               absolute: 11
             strategy: auto
-            flush-period:
-              secs: 160
-              nanos: 0
+            flush-period: 2m 40s
         "#,
         )
         .expect("config");

--- a/crates/fluvio-connector-package/test-data/connectors/full-config-v2.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/full-config-v2.yaml
@@ -36,9 +36,7 @@ meta:
       start:
         absolute: 100
       strategy: auto
-      flush-period:
-        secs: 160
-        nanos: 0
+      flush-period: 2m 40s
   secrets:
     - name: secret1
 transforms:


### PR DESCRIPTION
Fixes #4274
The flush-period field in ConsumerOffsetConfig now supports human-readable duration strings using humantime_serde, consistent with the linger field in ProducerParameters.
**Before:**
flush-period required verbose struct format:
  flush-period:
    secs: 10
    nanos: 0
**After:**
flush-period accepts humantime strings:
  flush-period: 10s
**Changes:**
- Added humantime_serde serde attribute to flush_period in ConsumerOffsetConfig
- Updated test_ser_consumer_offset_config to expect humantime string output
- Updated test_deser_consumer_offset_config to accept humantime string input
- Updated test-data/connectors/full-config-v2.yaml to use humantime format (2m 40s)